### PR TITLE
checkUpdateAssistant.js: Fix incorrect call for closing notifications

### DIFF
--- a/service/javascript/assistants/checkUpdateAssistant.js
+++ b/service/javascript/assistants/checkUpdateAssistant.js
@@ -153,7 +153,7 @@ CheckUpdateAssistant.prototype.run = function (outerFuture) {
 
                 //notify user that we have an update
                 //first close all old notifications, then create a new one.
-                PalmCall.call("palm://org.webosports.notifications", "closeAllNotifications", {}).then(function () {
+                PalmCall.call("palm://org.webosports.notifications", "closeAll", {}).then(function () {
                     PalmCall.call("palm://org.webosports.notifications", "create", {
                         ownerId: "org.webosports.service.update",
                         launchId: "org.webosports.app.settings",


### PR DESCRIPTION
May 02 14:03:02 qemux86-64 ls-hubd[257]: Error: palm://org.webosports.notifications/closeAllNotifications {}: Unknown method "closeAllNotifications" for category "/"

There is no such method as "closeAllNotifications" only "closeAll" as per https://github.com/webOS-ports/luna-next-cardshell/blob/master/qml/LunaSysAPI/NotificationService.qml#L37.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>