### PR TITLE
config.js, util.js: Fix typos and expand regexp

### DIFF
--- a/service/javascript/config.js
+++ b/service/javascript/config.js
@@ -5,14 +5,14 @@ var Config = {
     versionFile: "/etc/luneos-release",
     //regexp to parse webos-release file. Will return:
     //${BUILD_DISTRIB_ID} release ${DISTRO_VERSION}-${BUILD_TREE}-${WEBOS_DISTRO_BUILD_ID} (${WEBOS_DISTRO_RELEASE_CODENAME})
-    //where ${WEBOS_DISTRO_BUILD_ID} is ${PLATTFORMVERSION}-${BUILD}
+    //where ${WEBOS_DISTRO_BUILD_ID} is ${PLATFORMVERSION}-${BUILD}
     //and BUILD_TREE is one of stable, testing, unstable.
-    parseWholeStringRegExp: /([0-9\._\-A-Za-z]+) release ([0-9\.]+)-([A-Za-z]+)-([0-9]+)-([0-9]+) \(([0-9a-zA-Z_\-\.]+)\)/,
+    parseWholeStringRegExp: /([0-9\._\-A-Za-z]+) release ([0-9\.]+)-([A-Za-z\/\-0-9]+)-([0-9]+)-([0-9]+) \(([0-9a-zA-Z_\-\.]+)\)/,
     parseWholeStringIndex: 4,
     parseWholeStringBuildTreeIndex: 3,
     parseWholeStringBuildIndex: 5,
     parseWholeStringCodenameIndex: 6,
-    parseOnlyPlattformVersionRegExp: /.*?-([0-9]+)-.*?/,
+    parseOnlyPlatformVersionRegExp: /.*?-([0-9]+)-.*?/,
 
     //download image:
     downloadPath: "/userdata/luneos-data/",

--- a/service/javascript/utils/utils.js
+++ b/service/javascript/utils/utils.js
@@ -38,7 +38,7 @@ var Utils = (function () {
 
                     if (!version && version !== 0) {
                         log("WARNING: Using parsing fallback. Better adjust parseWholeStringRegExp.");
-                        matches = Config.parseOnlyPlattformVersionRegExp.exec(dataStr);
+                        matches = Config.parseOnlyPlatformVersionRegExp.exec(dataStr);
                         version = matches && parseInt(matches[1], 10); //first match is always the complete string.
 
                         codename = dataStr.substring(dataStr.lastIndexOf("(") + 1, dataStr.length - 2);


### PR DESCRIPTION
The regexp wasn't picking up branches with - / or 0-9 in it. Expanded the regexp so it works correctly with jansa/master, herrie/supported-targets, herrie/qt59 for example.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>