### PR TITLE
org.webosports.update: Fix LS2 calls

### DIFF
--- a/files/sysbus/org.webosports.service.update.perm.json
+++ b/files/sysbus/org.webosports.service.update.perm.json
@@ -4,6 +4,8 @@
         "activity.query",
         "download.management",
         "networkconnection.query",
+        "notification.management",
+        "notification.operation",
         "systemsettings.query",
         "update-service.operation"
     ]

--- a/service/activities/org.webosports.service.update/org.webosports.service.update.check
+++ b/service/activities/org.webosports.service.update/org.webosports.service.update.check
@@ -3,7 +3,7 @@
         "name": "org.webosports.service.update: Periodic Update Check",
         "description": "Periodic system update check",
         "callback": {
-            "method": "palm://org.webosports.service.update/checkUpdate",
+            "method": "luna://org.webosports.service.update/checkUpdate",
             "params": {}
         },
         "requirements" : {

--- a/service/javascript/assistants/downloadUpdateAssistant.js
+++ b/service/javascript/assistants/downloadUpdateAssistant.js
@@ -58,7 +58,7 @@ DownloadUpdateAssistant.prototype.run = function (outerFuture, subscription) {
         }
     }
 
-    future.nest(PalmCall.call("palm://com.palm.connectionmanager", "getStatus", {subscribe: false}));
+    future.nest(PalmCall.call("luna://com.webos.service.connectionmanager", "getStatus", {subscribe: false}));
 
     future.then(function readUpdateResults() {
         var result = Utils.checkResult(future);
@@ -87,7 +87,7 @@ DownloadUpdateAssistant.prototype.run = function (outerFuture, subscription) {
                 result.deviceImages[updateData.deviceName][updateData.version]) {
                 url = result.deviceImages[updateData.deviceName][updateData.version].url;
                 debug("Got url: " + url);
-                PalmCall.call("palm://com.palm.downloadmanager", "download", {
+                PalmCall.call("luna://com.webos.service.downloadmanager", "download", {
                     target: url,
                     keepFilenameOnRedirect: true,
                     targetFilename: Config.downloadFilename,

--- a/service/javascript/utils/activities.js
+++ b/service/javascript/utils/activities.js
@@ -29,10 +29,10 @@ var ActivityHelper = (function () {
                 },
                 schedule:     { interval: "24h", precise: false },
                 requirements: { internet: true },
-                callback:     { method: "palm://org.webosports.update/checkUpdate"}
+                callback:     { method: "luna://org.webosports.service.update/checkUpdate"}
             };
 
-            future.nest(PalmCall.call("palm://com.palm.activitymanager/", "create", {
+            future.nest(PalmCall.call("luna://com.webos.service.activitymanager/", "create", {
                 activity: activity,
                 replace: true,
                 start: true
@@ -52,7 +52,7 @@ var ActivityHelper = (function () {
 
             //This currently gives bad exceptions and some kind of timeout in OWO. ActivityManager not working??? :(
             log("activityManager => getDetails");
-            future.nest(PalmCall.call("palm://com.palm.activitymanager/", "getDetails", {
+            future.nest(PalmCall.call("luna://com.webos.service.activitymanager/", "getDetails", {
                 activityName: activityName,
                 current: true,
                 internal: true


### PR DESCRIPTION
- Update LS2 calls to new API's (legacy ones still work, but good to update to new ones if we're anyway at it).
- Use Toasts instead of Notifications. We dropped luna-next which provided the notifications for us. We'll now use notificationmgr from OSE which only provides Toasts or Alerts with a different (and more limited) syntax.